### PR TITLE
Drive-v2: Team-Drive snippets UnitTest

### DIFF
--- a/drive/snippets/drive_v2/src/main/java/CreateTeamDrive.java
+++ b/drive/snippets/drive_v2/src/main/java/CreateTeamDrive.java
@@ -35,7 +35,7 @@ public class CreateTeamDrive {
      * @return Newly created drive id.
      * @throws IOException if service account credentials file not found.
      */
-    private static String createTeamDrive() throws IOException {
+    public static String createTeamDrive() throws IOException {
         /*Load pre-authorized user credentials from the environment.
         TODO(developer) - See https://developers.google.com/identity for
         guides on implementing OAuth2 for your application.*/

--- a/drive/snippets/drive_v2/src/main/java/RecoverTeamDrive.java
+++ b/drive/snippets/drive_v2/src/main/java/RecoverTeamDrive.java
@@ -39,7 +39,7 @@ public class RecoverTeamDrive {
      * @return  All team drives without an organizer.
      * @throws IOException if service account credentials file not found.
      */
-    private static List<TeamDrive> recoverTeamDrives(String realUser) throws IOException {
+    public static List<TeamDrive> recoverTeamDrives(String realUser) throws IOException {
         /*Load pre-authorized user credentials from the environment.
         TODO(developer) - See https://developers.google.com/identity for
         guides on implementing OAuth2 for your application.*/

--- a/drive/snippets/drive_v2/src/test/java/TestCreateTeamDrive.java
+++ b/drive/snippets/drive_v2/src/test/java/TestCreateTeamDrive.java
@@ -1,0 +1,15 @@
+import org.junit.Test;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import static org.junit.Assert.assertNotNull;
+
+public class TestCreateTeamDrive extends BaseTest{
+    @Test
+    public void createTeamDrive() throws IOException, GeneralSecurityException {
+        String id = CreateTeamDrive.createTeamDrive();
+        assertNotNull(id);
+        this.service.teamdrives().delete(id);
+    }
+}

--- a/drive/snippets/drive_v2/src/test/java/TestRecoverTeamDrives.java
+++ b/drive/snippets/drive_v2/src/test/java/TestRecoverTeamDrives.java
@@ -1,0 +1,32 @@
+import com.google.api.services.drive.model.Permission;
+import com.google.api.services.drive.model.PermissionList;
+import com.google.api.services.drive.model.TeamDrive;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertNotEquals;
+
+public class TestRecoverTeamDrives extends BaseTest{
+    @Test
+    public void recoverTeamDrives() throws IOException {
+        String id = this.createOrphanedTeamDrive();
+        List<TeamDrive> results = RecoverTeamDrive.recoverTeamDrives(
+                "sbazyl@test.appsdevtesting.com");
+        assertNotEquals(0, results.size());
+        this.service.teamdrives().delete(id).execute();
+    }
+    private String createOrphanedTeamDrive() throws IOException {
+        String teamDriveId = CreateTeamDrive.createTeamDrive();
+        PermissionList response = this.service.permissions().list(teamDriveId)
+                .setSupportsTeamDrives(true)
+                .execute();
+        for (Permission permission : response.getItems()) {
+            this.service.permissions().delete(teamDriveId, permission.getId())
+                    .setSupportsTeamDrives(true)
+                    .execute();
+        }
+        return teamDriveId;
+    }
+}


### PR DESCRIPTION
# Description

Unit test cases for drive-v2 change snippets of region tags:

drive_create_team_drive
drive_recover_team_drives

Fixes # (234303996,234304227)

## Is it been tested?
- [X] Development testing done

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have performed a peer-reviewed with team member(s)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
