### PR TITLE
Drive-v3: File snippets UnitTest patch4

### DIFF
--- a/drive/snippets/drive_v3/src/main/java/CreateFolder.java
+++ b/drive/snippets/drive_v3/src/main/java/CreateFolder.java
@@ -36,7 +36,7 @@ public class CreateFolder {
      * @return Inserted folder id if successful, {@code null} otherwise.
      * @throws IOException if service account credentials file not found.
      */
-    private static String createFolder() throws IOException {
+    public static String createFolder() throws IOException {
         // Load pre-authorized user credentials from the environment.
         // TODO(developer) - See https://developers.google.com/identity for
         // guides on implementing OAuth2 for your application.

--- a/drive/snippets/drive_v3/src/main/java/MoveFileToFolder.java
+++ b/drive/snippets/drive_v3/src/main/java/MoveFileToFolder.java
@@ -38,7 +38,7 @@ public class MoveFileToFolder {
      * @param folderId Id of folder where the fill will be moved.
      * @return list of parent ids for the file.
      * */
-    private static List<String> moveFileToFolder(String fileId, String folderId)
+    public static List<String> moveFileToFolder(String fileId, String folderId)
             throws IOException {
         /* Load pre-authorized user credentials from the environment.
         TODO(developer) - See https://developers.google.com/identity for

--- a/drive/snippets/drive_v3/src/main/java/SearchFile.java
+++ b/drive/snippets/drive_v3/src/main/java/SearchFile.java
@@ -37,7 +37,7 @@ public class SearchFile {
      * @return search result list.
      * @throws IOException if service account credentials file not found.
      */
-    private static List<File> searchFile() throws IOException{
+    public static List<File> searchFile() throws IOException{
            /*Load pre-authorized user credentials from the environment.
            TODO(developer) - See https://developers.google.com/identity for
            guides on implementing OAuth2 for your application.*/

--- a/drive/snippets/drive_v3/src/main/java/ShareFile.java
+++ b/drive/snippets/drive_v3/src/main/java/ShareFile.java
@@ -44,7 +44,7 @@ public class ShareFile {
      * @return list of modified permissions if successful, {@code null} otherwise.
      * @throws IOException if service account credentials file not found.
      */
-    private static List<String> shareFile(String realFileId, String realUser, String realDomain) throws IOException{
+    public static List<String> shareFile(String realFileId, String realUser, String realDomain) throws IOException{
         /* Load pre-authorized user credentials from the environment.
          TODO(developer) - See https://developers.google.com/identity for
          guides on implementing OAuth2 for your application.application*/

--- a/drive/snippets/drive_v3/src/test/java/TestCreateFolder.java
+++ b/drive/snippets/drive_v3/src/test/java/TestCreateFolder.java
@@ -1,0 +1,15 @@
+import org.junit.Test;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import static org.junit.Assert.assertNotNull;
+
+public class TestCreateFolder extends BaseTest{
+    @Test
+    public void createFolder() throws IOException, GeneralSecurityException {
+        String id = CreateFolder.createFolder();
+        assertNotNull(id);
+        deleteFileOnCleanup(id);
+    }
+}

--- a/drive/snippets/drive_v3/src/test/java/TestMoveFileToFolder.java
+++ b/drive/snippets/drive_v3/src/test/java/TestMoveFileToFolder.java
@@ -1,0 +1,22 @@
+import org.junit.Test;
+
+import javax.annotation.CheckReturnValue;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestMoveFileToFolder extends BaseTest{
+    @Test
+    public void moveFileToFolder()
+            throws IOException, GeneralSecurityException {
+        String folderId = CreateFolder.createFolder();
+        deleteFileOnCleanup(folderId);
+        String fileId = this.createTestBlob();
+        List<String> parents = MoveFileToFolder.moveFileToFolder(fileId, folderId);
+        assertTrue(parents.contains(folderId));
+        assertEquals(1, parents.size());
+    }
+}

--- a/drive/snippets/drive_v3/src/test/java/TestSearchFiles.java
+++ b/drive/snippets/drive_v3/src/test/java/TestSearchFiles.java
@@ -1,0 +1,18 @@
+import com.google.api.services.drive.model.File;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+
+import static org.junit.Assert.assertNotEquals;
+
+public class TestSearchFiles extends BaseTest{
+    @Test
+    public void searchFiles()
+            throws IOException, GeneralSecurityException {
+        this.createTestBlob();
+        List<File> files = SearchFile.searchFile();
+        assertNotEquals(0, files.size());
+    }
+}

--- a/drive/snippets/drive_v3/src/test/java/TestShareFile.java
+++ b/drive/snippets/drive_v3/src/test/java/TestShareFile.java
@@ -1,0 +1,17 @@
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestShareFile extends BaseTest{
+    @Test
+    public void shareFile() throws IOException {
+        String fileId = this.createTestBlob();
+        List<String> ids = ShareFile.shareFile(fileId,
+                "user@test.appsdevtesting.com",
+                "test.appsdevtesting.com");
+        assertEquals(2, ids.size());
+    }
+}


### PR DESCRIPTION
# Description

Unit test cases for drive-v3 change snippets of region tags:

drive_create_folder
drive_move_file_to_folder
drive_search_files
drive_share_file

Fixes # (235154163,235154051,235154286,235154172)

## Is it been tested?
- [X] Development testing done

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have performed a peer-reviewed with team member(s)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
