### PR TITLE
Drive-v3: Change snippets UnitTest

### DIFF
--- a/drive/snippets/drive_v3/src/main/java/FetchChanges.java
+++ b/drive/snippets/drive_v3/src/main/java/FetchChanges.java
@@ -34,7 +34,7 @@ public class FetchChanges {
      * @return Saved token after last page.
      * @throws IOException if file is not found
      */
-    private static String fetchChanges(String savedStartPageToken) throws IOException {
+    public static String fetchChanges(String savedStartPageToken) throws IOException {
 
         /*Load pre-authorized user credentials from the environment.
         TODO(developer) - See https://developers.google.com/identity for

--- a/drive/snippets/drive_v3/src/main/java/FetchStartPageToken.java
+++ b/drive/snippets/drive_v3/src/main/java/FetchStartPageToken.java
@@ -34,7 +34,7 @@ public class FetchStartPageToken {
      * @return Start page token as String.
      * @throws IOException if file is not found
      */
-    private static String fetchStartPageToken() throws IOException {
+    public static String fetchStartPageToken() throws IOException {
         /*Load pre-authorized user credentials from the environment.
         TODO(developer) - See https://developers.google.com/identity for
         guides on implementing OAuth2 for your application. */

--- a/drive/snippets/drive_v3/src/test/java/TestFetchChanges.java
+++ b/drive/snippets/drive_v3/src/test/java/TestFetchChanges.java
@@ -1,0 +1,32 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+// Unit test class for fetchChanges change snippet
+public class TestFetchChanges extends BaseTest{
+    @Test
+    public void fetchChanges() throws IOException {
+        String startPageToken = FetchStartPageToken.fetchStartPageToken();
+        this.createTestBlob();
+        String newStartPageToken = FetchChanges.fetchChanges(startPageToken);
+        assertNotNull(newStartPageToken);
+        assertNotEquals(startPageToken, newStartPageToken);
+    }
+}

--- a/drive/snippets/drive_v3/src/test/java/TestFetchStartPageToken.java
+++ b/drive/snippets/drive_v3/src/test/java/TestFetchStartPageToken.java
@@ -1,0 +1,28 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertNotNull;
+
+// Unit test class for fetchStartPageToken change snippet
+public class TestFetchStartPageToken extends BaseTest{
+    @Test
+    public void fetchStartPageToken() throws IOException {
+        String token = FetchStartPageToken.fetchStartPageToken();
+        assertNotNull(token);
+    }
+}


### PR DESCRIPTION
# Description

Unit test cases for drive-v3 change snippets of region tags:

drive_fetch_start_page_token
drive_fetch_changes

Fixes # (235533840,235534417)

## Is it been tested?
- [X] Development testing done

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have performed a peer-reviewed with team member(s)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
